### PR TITLE
read hierarchical yaml file correctly.

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -7,16 +7,31 @@ type conf map[string]interface{}
 func (c conf) toArgs(positions ...string) []string {
 
 	nowConf := c
+ConfLoop:
 	for _, p := range positions {
 		nextConf, ok := nowConf[p]
 		if !ok {
 			return []string{}
 		}
 		n, ok := nextConf.(map[string]interface{})
-		if !ok {
-			break
+		if ok {
+			nowConf = n
+			continue
 		}
-		nowConf = n
+		n2, ok := nextConf.(map[interface{}]interface{})
+		if !ok {
+			continue
+		}
+		// Convert map[interface{}] to map[string]
+		tmp := map[string]interface{}{}
+		for k, v := range(n2) {
+			key, ok := k.(string)
+			if !ok {
+				continue ConfLoop
+			}
+			tmp[key] = v
+		}
+		nowConf = tmp
 	}
 
 	var args []string

--- a/parser_test.go
+++ b/parser_test.go
@@ -10,7 +10,7 @@ import (
 
 type ParseTest struct {
 	configString string
-	expected     map[string]interface{}
+	expected     interface{}
 }
 
 type ParseErrorTest struct {
@@ -128,6 +128,20 @@ func TestParseYaml(t *testing.T) {
 			"flag1: value1\nflag2: value2\n",
 			map[string]interface{}{"flag1": "value1", "flag2": "value2"},
 		},
+		ParseTest{
+`env1:
+  flag1: value1
+  flag2: "value2"
+# line comment
+env2:
+  flag1: 12345	# inline comment
+  flag2: -1.41421356`,
+			interface{}(map[string]interface{}{
+				"env1":map[interface{}]interface{}{"flag1": "value1", "flag2": "value2"},
+				"env2":map[interface{}]interface{}{"flag1": 12345, "flag2": -1.41421356},
+			}),
+		},
+
 	}
 
 	for _, a := range asserts {


### PR DESCRIPTION
Parse yaml file that have hierarchy by yaml.Unmarshal(), it returns map[string]map[interface{}]interface{}. 

But toArgs() supposes map[string]map[string]interface{}. Then it fail to read config with positions.
